### PR TITLE
Fix bug to exclude hosts(with port) for proxy

### DIFF
--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -256,7 +256,9 @@ export class HttpClient {
             } else {
                 // if port specified, match host without port or hostname:port exactly match
                 let [ph, pp] = urlParts;
-                return ph === hostName && (!pp || pp === port);
+                if (ph === hostName && (!pp || pp === port)) {
+                    return true
+                }
             }
         }
 


### PR DESCRIPTION
Only the first one in ignore host(with port) take effect in "rest-client.excludeHostsForProxy".